### PR TITLE
Add win32 core dump (#4291)

### DIFF
--- a/server/main.cpp
+++ b/server/main.cpp
@@ -41,9 +41,7 @@
 #include "ZLMVersion.h"
 #endif
 
-#if !defined(_WIN32)
 #include "System.h"
-#endif//!defined(_WIN32)
 
 using namespace std;
 using namespace toolkit;
@@ -259,10 +257,11 @@ int start_main(int argc,char *argv[]) {
             // Start daemon process
             System::startDaemon(kill_parent_if_failed);
         }
+#endif //! defined(_WIN32)
+
         // 开启崩溃捕获等  [AUTO-TRANSLATED:9c7c759c]
         // Enable crash capture, etc.
         System::systemSetup();
-#endif//!defined(_WIN32)
 
         // 启动异步日志线程  [AUTO-TRANSLATED:c93cc6f4]
         // Start asynchronous log thread


### PR DESCRIPTION
单元测试代码
int main() {
    System::systemSetup();
    int *p = nullptr;
    *p = 1; // 强制崩溃
    return 0;
}

崩溃后直接用 vs2019(2022) 打开 dmp 文件。
菜单选择 File → Open → File...，选择你的 .dmp 文件。
提示你“选择符号和源码”，若有源码和 pdb/symbol 文件能看到更详细的堆栈。